### PR TITLE
refactor: guarantee we do not deliver a result (invoke the completion…

### DIFF
--- a/EssentialFeed/Feed API/RemoteFeedLoader.swift
+++ b/EssentialFeed/Feed API/RemoteFeedLoader.swift
@@ -28,7 +28,9 @@ public final class RemoteFeedLoader {
     }
     
     public func load(completion: @escaping (Result) -> Void) {
-        client.get(from: url) { result in
+        client.get(from: url) { [weak self] result in
+            guard self != nil else { return }
+            
             switch result {
             case let .success(data, response):
                 completion(FeedItemsMapper.map(data, from: response))

--- a/EssentialFeedTests/RemoteFeedLoaderTests.swift
+++ b/EssentialFeedTests/RemoteFeedLoaderTests.swift
@@ -96,6 +96,20 @@ class RemoteFeedLoaderTests: XCTestCase {
         })
     }
     
+    func test_load_doesNotDeliverResultAfterSUTInstanceHasBeenDeallocated() {
+        let url = URL(string: "https://any-url.com")!
+        let client = HTTPClientSpy()
+        var sut: RemoteFeedLoader? = RemoteFeedLoader(url: url, client: client)
+        
+        var capturedResults = [RemoteFeedLoader.Result]()
+        sut?.load { capturedResults.append($0) }
+        
+        sut = nil
+        client.complete(withStatusCode: 200, data: makeItemsJSON([]))
+        
+        XCTAssertTrue(capturedResults.isEmpty)
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(url: URL = URL(string: "https://a-url.com")!,  file: StaticString = #file, line: UInt = #line) -> (sut: RemoteFeedLoader, client: HTTPClientSpy) {


### PR DESCRIPTION
… closure) after the RemoteFeedLoader instance has been deallocated