### PR TITLE
Update CI-iOS workflow with timeout and simulator changes

### DIFF
--- a/.github/workflows/CI-iOS.yml
+++ b/.github/workflows/CI-iOS.yml
@@ -1,4 +1,3 @@
-
 name: CI-iOS
 
 on:
@@ -8,25 +7,27 @@ on:
 jobs:
   build-and-test:
     runs-on: macos-latest
-    timeout-minutes: 15 # Increased slightly as TSan and Clean builds take time
+    timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
 
-    - name: Select Xcode
-      # Using a glob pattern or the specific path to ensure we use the latest available
+    - name: Select Xcode Version
+      # Based on your log, the path is /Applications/Xcode_26.1.1.app
       run: sudo xcode-select -switch /Applications/Xcode_26.1.1.app
 
     - name: Xcode version
       run: xcodebuild -version
 
     - name: Build and Test
+      # Using the exact name and OS found in your available destinations log
       run: |
         xcodebuild clean build test \
           -workspace EssentialApp/EssentialApp.xcworkspace \
           -scheme "CI_iOS" \
           -sdk iphonesimulator \
-          -destination "platform=iOS Simulator,OS=26.1" \
+          -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.1" \
           -enableThreadSanitizer YES \
           ONLY_ACTIVE_ARCH=YES \
           CODE_SIGNING_REQUIRED=NO \


### PR DESCRIPTION
Increased timeout for the build-and-test job and updated the Xcode selection step. Modified the destination for the iOS Simulator to use a specific device.